### PR TITLE
Added support for Pug JSX templates

### DIFF
--- a/redhorsedev-pug.novaextension/Syntaxes/redhorsedev-jsx.xml
+++ b/redhorsedev-pug.novaextension/Syntaxes/redhorsedev-jsx.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<syntax name="pug-jsx">
+	<meta>
+		<name>Pug JSX</name>
+		<type>script</type>
+		<preferred-file-extension>js</preferred-file-extension>
+		<parent>javascript</parent>
+	</meta>
+	
+	<detectors>
+		<match-content priority="1.0">pug\`</match-content>
+		<extension priority="0.7">js</extension>
+	</detectors>
+	
+	<scopes>
+		<include syntax="javascript" />
+	</scopes>
+	
+	<template-scopes>
+		<scope name="pug-jsx.template">
+			<starts-with>
+				<expression>pug\`</expression>
+			</starts-with>
+			<ends-with>
+				<expression>\`</expression>
+			</ends-with>
+			<subsyntax name="pug" />
+		</scope>
+	</template-scopes>
+</syntax>


### PR DESCRIPTION
I've added basic support for Pug's official JSX plugin for Babel (see [pugjs/babel-plugin-transform-react-pug](https://github.com/pugjs/babel-plugin-transform-react-pug)).

The main bit I couldn't figure out was that the detector doesn't trigger on `.js` files, strangely it only works if the extension is  something else. Also, it doesn't support [nested templates via interpolation](https://github.com/pugjs/babel-plugin-transform-react-pug#interpolation).